### PR TITLE
Return null string for null values

### DIFF
--- a/src/main/java/org/cloudburstmc/nbt/NbtUtils.java
+++ b/src/main/java/org/cloudburstmc/nbt/NbtUtils.java
@@ -106,7 +106,9 @@ public class NbtUtils {
     }
 
     public static String toString(Object o) {
-        if (o instanceof Byte) {
+        if (o == null) {
+            return "null";
+        } else if (o instanceof Byte) {
             return ((byte) o) + "b";
         } else if (o instanceof Short) {
             return ((short) o) + "s";


### PR DESCRIPTION
I was testing whether two SetEntityDataPackets were equal using junit.
They weren't equal due to a null value for a string. junit tries to show you the SetEntityDataPacket#toString but has to fallback due to it throwing a nullpointer on this method.
![image](https://github.com/user-attachments/assets/7479feb7-2687-4722-85f3-2c3b2c193799)
I'm aware that if you would try to send the packet it'll fail to serialize (due to the string being null), but that doesn't happen with tests and it's nice to know what's wrong.