### PR TITLE
Hash primitive arrays deeply in NbtMap and NbtList

### DIFF
--- a/src/main/java/org/cloudburstmc/nbt/NbtList.java
+++ b/src/main/java/org/cloudburstmc/nbt/NbtList.java
@@ -63,9 +63,12 @@ public class NbtList<E> extends AbstractList<E> {
 
     @Override
     public int hashCode() {
-        if (this.hashCodeGenerated) return this.hashCode;
-        int result = Objects.hash(super.hashCode(), type);
-        result = 31 * result + Arrays.deepHashCode(array);
+        if (this.hashCodeGenerated)
+            return this.hashCode;
+        int result = type.hashCode();
+        for (Object object : array) {
+            result = 31 * result + NbtUtils.hashCode(object);
+        }
         this.hashCode = result;
         this.hashCodeGenerated = true;
         return result;

--- a/src/main/java/org/cloudburstmc/nbt/NbtMap.java
+++ b/src/main/java/org/cloudburstmc/nbt/NbtMap.java
@@ -386,12 +386,14 @@ public class NbtMap extends AbstractMap<String, Object> {
     public int hashCode() {
         if (this.hashCodeGenerated)
             return this.hashCode;
-        int h = 0;
-        for (Entry<String, Object> stringObjectEntry : this.map.entrySet())
-            h += stringObjectEntry.hashCode();
-        this.hashCode = h;
+        int result = 1;
+        for (Entry<String, Object> stringObjectEntry : this.map.entrySet()) {
+            result = 31 * result + (stringObjectEntry.getKey().hashCode()
+                    ^ NbtUtils.hashCode(stringObjectEntry.getValue()));
+        }
+        this.hashCode = result;
         this.hashCodeGenerated = true;
-        return h;
+        return result;
     }
 
     @Override

--- a/src/main/java/org/cloudburstmc/nbt/NbtUtils.java
+++ b/src/main/java/org/cloudburstmc/nbt/NbtUtils.java
@@ -175,4 +175,17 @@ public class NbtUtils {
         }
         return r.toString();
     }
+
+    static int hashCode(Object object) {
+        if (object instanceof byte[]) {
+            return Arrays.hashCode((byte[]) object);
+        }
+        if (object instanceof int[]) {
+            return Arrays.hashCode((int[]) object);
+        }
+        if (object instanceof long[]) {
+            return Arrays.hashCode((long[]) object);
+        }
+        return object.hashCode();
+    }
 }

--- a/src/test/java/org/cloudburstmc/nbt/NbtTests.java
+++ b/src/test/java/org/cloudburstmc/nbt/NbtTests.java
@@ -71,6 +71,7 @@ class NbtTests {
         try (NBTInputStream in = NbtUtils.createNetworkReader(bais)) {
             Object o = in.readTag();
             Assertions.assertEquals(TEST_MAP, o);
+            Assertions.assertEquals(TEST_MAP.hashCode(), o.hashCode());
         } catch (Exception e) {
             throw new AssertionError("Error whilst decoding tag", e);
         }


### PR DESCRIPTION
Hash primitive arrays deeply in NbtMap and NbtList as they come unwrapped.

Calling hashCode on just byte[] int[] and long[] returns the object hashCode not a hashCode reflecting the contents.

Also extended the write-read test to check the hashCode after the equal check.

This alters the hashCode generation slightly, but they are only valid per runtime anyway (as types are also hashed and there hashCode is not stable)